### PR TITLE
:bug: Patching samples raises USIConnectionError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ TODO
 0.3.1.dev0
 ----------
 
+* fix a bug when patching a sample: deal with team in relationship
 * Change ``Auth.__str__()``: now it returns ``Token for Foo Bar will expire in HH:MM:SS``
 * add ``Auth.get_domains`` which returns ``self.claims['domains']``
 

--- a/pyUSIrest/client.py
+++ b/pyUSIrest/client.py
@@ -143,7 +143,8 @@ class Client():
         # TODO: evaluate a list of expected status?
         if response.status_code != expected_status:
             raise USIConnectionError(
-                "%s:%s" % (response.status_code, response.text))
+                "Got a status code different than expected: %s (%s)" % (
+                    response.status_code, response.text))
 
     def get(self, url, headers={}, params={}):
         """Generic GET method

--- a/pyUSIrest/client.py
+++ b/pyUSIrest/client.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse as parse_date
 
 from . import __version__
 from .auth import Auth
-from .exceptions import USIConnectionError, TokenExpiredError
+from .exceptions import USIConnectionError, USIDataError, TokenExpiredError
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +135,10 @@ class Client():
         if int(response.status_code / 100) == 5:
             raise USIConnectionError(
                 "Problems with API endpoints: %s" % response.text)
+
+        if int(response.status_code / 100) == 4:
+            raise USIDataError(
+                "Error with request: %s" % response.text)
 
         # TODO: evaluate a list of expected status?
         if response.status_code != expected_status:

--- a/pyUSIrest/usi.py
+++ b/pyUSIrest/usi.py
@@ -1192,16 +1192,8 @@ class Sample(TeamMixin, Document):
         url = self._links['self:delete']['href']
         logger.info("Removing sample %s from submission" % self.name)
 
-        response = Client.delete(self, url)
-
-        if response.status_code != 204:
-            raise USIConnectionError(response.text)
-
-        # assign attributes
-        self.last_response = response
-        self.last_status_code = response.status_code
-
         # don't return anything
+        Client.delete(self, url)
 
     def reload(self):
         """call :py:meth:`Document.follow_self_url` and reload class

--- a/pyUSIrest/usi.py
+++ b/pyUSIrest/usi.py
@@ -152,7 +152,7 @@ class Root(Document):
         try:
             submission.get(url)
 
-        except USIConnectionError as exc:
+        except USIDataError as exc:
             if submission.last_status_code == 404:
                 # if I arrive here, no submission is found
                 raise NameError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,8 @@ from unittest import TestCase
 from pyUSIrest.auth import Auth
 from pyUSIrest.client import Client
 from pyUSIrest.settings import ROOT_URL
-from pyUSIrest.exceptions import USIConnectionError, TokenExpiredError
+from pyUSIrest.exceptions import (
+    USIConnectionError, TokenExpiredError, USIDataError)
 
 from .common import DATA_PATH
 from .test_auth import generate_token
@@ -114,7 +115,7 @@ class ClientTest(TestCase):
         self.mock_get.return_value = response
 
         self.assertRaisesRegex(
-            USIConnectionError,
+            USIDataError,
             "Not Found",
             client.get,
             ROOT_URL + "/meow"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,13 +14,23 @@ from unittest.mock import patch, Mock
 from unittest import TestCase
 
 from pyUSIrest.auth import Auth
-from pyUSIrest.client import Client
+from pyUSIrest.client import Client, is_date
 from pyUSIrest.settings import ROOT_URL
 from pyUSIrest.exceptions import (
     USIConnectionError, TokenExpiredError, USIDataError)
 
 from .common import DATA_PATH
 from .test_auth import generate_token
+
+
+class ISDateTest(TestCase):
+    def test_is_date(self):
+        self.assertTrue(is_date("2018-07-16"))
+        self.assertTrue(is_date("2018-07-16T14:25:22.546"))
+        self.assertTrue(is_date("2018-07-16T14:25:22.546+0000"))
+
+    def test_is_not_date(self):
+        self.assertFalse(is_date("not a date"))
 
 
 class ClientTest(TestCase):
@@ -98,6 +108,28 @@ class ClientTest(TestCase):
         response = client.get(ROOT_URL, headers={'new_key': 'new_value'})
 
         self.assertIsInstance(response.json(), dict)
+
+    def test_get_wrong_status_code(self):
+        """Testing a get method with a different status code than expected"""
+
+        # create a mock response
+        with open(os.path.join(DATA_PATH, "root.json")) as handle:
+            data = json.load(handle)
+
+        self.mock_get.return_value = Mock()
+        self.mock_get.return_value.json.return_value = data
+        self.mock_get.return_value.text = "test message"
+        self.mock_get.return_value.status_code = 201
+
+        token = generate_token()
+        client = Client(token)
+
+        self.assertRaisesRegex(
+            USIConnectionError,
+            "Got a status code different than expected",
+            client.get,
+            ROOT_URL
+        )
 
     def test_get_with_errors(self):
         """Deal with problems with getting URL (no 200 status code)"""

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 from pyUSIrest.auth import Auth
 from pyUSIrest.usi import Root, Team, Submission
 from pyUSIrest.settings import ROOT_URL
+from pyUSIrest.exceptions import USIConnectionError, USIDataError
 
 from .common import DATA_PATH
 from .test_auth import generate_token
@@ -239,6 +240,6 @@ class RootTest(TestCase):
         self.mock_get.return_value.status_code = 500
 
         self.assertRaises(
-            ConnectionError,
+            USIConnectionError,
             self.root.get_submission_by_name,
             submission_name='c8c86558-8d3a-4ac5-8638-7aa354291d61')

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -236,6 +236,18 @@ class RootTest(TestCase):
             self.root.get_submission_by_name,
             submission_name='c8c86558-8d3a-4ac5-8638-7aa354291d61')
 
+        # a different 40x error type
+        self.mock_get.return_value = Mock()
+        self.mock_get.return_value.text = (
+            "The request did not include an Authorization header")
+        self.mock_get.return_value.status_code = 401
+
+        self.assertRaisesRegex(
+            USIDataError,
+            "Error with request",
+            self.root.get_submission_by_name,
+            submission_name='c8c86558-8d3a-4ac5-8638-7aa354291d61')
+
         self.mock_get.return_value = Mock()
         self.mock_get.return_value.status_code = 500
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This will fix a bug when patching a `Sample` in a `Draft` submission. Now the team name is read correctly and used in the correct way when patching or creating a new `Sample` object

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #8 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR will fix a bug when patching a sample

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with unittest and by testing InjectTool by patching or creating samples in a submission

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
