### PR TITLE
:bookmark: pyUSIrest release v0.3.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ TODO
 0.3.1.dev0
 ----------
 
+* fix a bug when patching a sample: deal with team in relationship
 * Change ``Auth.__str__()``: now it returns ``Token for Foo Bar will expire in HH:MM:SS``
 * add ``Auth.get_domains`` which returns ``self.claims['domains']``
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,12 @@ TODO
 * filtering sample by status or error make a lot of queries. Consider writing
   coroutines or reading ValidationResult as pages
 
+0.3.1.dev0
+----------
+
+* Change ``Auth.__str__()``: now it returns ``Token for Foo Bar will expire in HH:MM:SS``
+* add ``Auth.get_domains`` which returns ``self.claims['domains']``
+
 0.3.0 (2020-01-14)
 ------------------
 

--- a/pyUSIrest/__init__.py
+++ b/pyUSIrest/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Paolo Cozzi"""
 __email__ = 'cozzi@ibba.cnr.it'
-__version__ = '0.3.0'
+__version__ = '0.3.1.dev0'

--- a/pyUSIrest/auth.py
+++ b/pyUSIrest/auth.py
@@ -167,6 +167,15 @@ class Auth():
             return "Token for {user} is expired".format(
                 user=self.claims['name'])
         else:
-            return "Token for {user} will last {duration}".format(
+            return "Token for {user} will expire in {duration}".format(
                 user=self.claims['name'],
                 duration=formatted)
+
+    def get_domains(self):
+        """Returns a list of domain managed by this object
+
+        Returns:
+            list: a list of managed domains
+        """
+
+        return self.claims['domains']

--- a/pyUSIrest/client.py
+++ b/pyUSIrest/client.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse as parse_date
 
 from . import __version__
 from .auth import Auth
-from .exceptions import USIConnectionError, TokenExpiredError
+from .exceptions import USIConnectionError, USIDataError, TokenExpiredError
 
 logger = logging.getLogger(__name__)
 
@@ -136,10 +136,15 @@ class Client():
             raise USIConnectionError(
                 "Problems with API endpoints: %s" % response.text)
 
+        if int(response.status_code / 100) == 4:
+            raise USIDataError(
+                "Error with request: %s" % response.text)
+
         # TODO: evaluate a list of expected status?
         if response.status_code != expected_status:
             raise USIConnectionError(
-                "%s:%s" % (response.status_code, response.text))
+                "Got a status code different than expected: %s (%s)" % (
+                    response.status_code, response.text))
 
     def get(self, url, headers={}, params={}):
         """Generic GET method

--- a/pyUSIrest/usi.py
+++ b/pyUSIrest/usi.py
@@ -152,7 +152,7 @@ class Root(Document):
         try:
             submission.get(url)
 
-        except USIConnectionError as exc:
+        except USIDataError as exc:
             if submission.last_status_code == 404:
                 # if I arrive here, no submission is found
                 raise NameError(
@@ -689,7 +689,41 @@ def check_releasedate(sample_data):
     return sample_data
 
 
-class Submission(Document):
+class TeamMixin(object):
+
+    def __init__(self):
+        """Instantiate the class"""
+
+        # my class attributes
+        self._team = None
+
+    @property
+    def team(self):
+        """Get/Set team name"""
+
+        # get team name
+        if isinstance(self._team, str):
+            team_name = self._team
+
+        elif isinstance(self._team, dict):
+            team_name = self._team['name']
+
+        elif self._team is None:
+            team_name = ""
+
+        else:
+            raise NotImplementedError(
+                "Unknown type: %s" % type(self._team)
+            )
+
+        return team_name
+
+    @team.setter
+    def team(self, value):
+        self._team = value
+
+
+class Submission(TeamMixin, Document):
     """A class to deal with USI Submissions_
 
     Attributes:
@@ -718,11 +752,13 @@ class Submission(Document):
         self.id = None
 
         # calling the base class method client
+        super().__init__()
+
+        # now setting up Client and document class attributes
         Client.__init__(self, auth)
         Document.__init__(self)
 
         # my class attributes
-        self._team = None
         self.createdDate = None
         self.lastModifiedDate = None
         self.lastModifiedBy = None
@@ -763,31 +799,6 @@ class Submission(Document):
                     "Overriding id (%s > %s)" % (self.id, submission_id))
 
         self.id = submission_id
-
-    @property
-    def team(self):
-        """Get/Set team name"""
-
-        # get team name
-        if isinstance(self._team, str):
-            team_name = self._team
-
-        elif isinstance(self._team, dict):
-            team_name = self._team['name']
-
-        elif self._team is None:
-            team_name = ""
-
-        else:
-            raise NotImplementedError(
-                "Unknown type: %s" % type(self._team)
-            )
-
-        return team_name
-
-    @team.setter
-    def team(self, value):
-        self._team = value
 
     def read_data(self, data, force_keys=False):
         """Read data from a dictionary object and set class attributes
@@ -871,11 +882,11 @@ class Submission(Document):
             Sample: a :py:class:`Sample` object"""
 
         # check sample_data for required attributes
-        sample_data = check_relationship(sample_data, self.team)
-        sample_data = check_releasedate(sample_data)
+        fixed_data = check_relationship(sample_data, self.team)
+        fixed_data = check_releasedate(fixed_data)
 
         # debug
-        logger.debug(sample_data)
+        logger.debug(fixed_data)
 
         # check if submission has the contents key
         if 'contents' not in self._links:
@@ -896,7 +907,7 @@ class Submission(Document):
         headers['Content-Type'] = 'application/json;charset=UTF-8'
 
         # call a post method a deal with response
-        response = self.post(url, payload=sample_data, headers=headers)
+        response = self.post(url, payload=fixed_data, headers=headers)
 
         # create a new sample
         sample = Sample(auth=self.auth, data=response.json())
@@ -1092,7 +1103,7 @@ class Submission(Document):
         return document
 
 
-class Sample(Document):
+class Sample(TeamMixin, Document):
     """A class to deal with USI Samples_
 
     Attributes:
@@ -1123,6 +1134,9 @@ class Sample(Document):
         """
 
         # calling the base class method client
+        super().__init__()
+
+        # now setting up Client and document class attributes
         Client.__init__(self, auth)
         Document.__init__(self)
 
@@ -1178,16 +1192,8 @@ class Sample(Document):
         url = self._links['self:delete']['href']
         logger.info("Removing sample %s from submission" % self.name)
 
-        response = Client.delete(self, url)
-
-        if response.status_code != 204:
-            raise USIConnectionError(response.text)
-
-        # assign attributes
-        self.last_response = response
-        self.last_status_code = response.status_code
-
         # don't return anything
+        Client.delete(self, url)
 
     def reload(self):
         """call :py:meth:`Document.follow_self_url` and reload class
@@ -1203,13 +1209,13 @@ class Sample(Document):
             sample_data (dict): sample data to update"""
 
         # check sample_data for required attributes
-        sample_data = check_relationship(sample_data, self.team)
-        sample_data = check_releasedate(sample_data)
+        fixed_data = check_relationship(sample_data, self.team)
+        fixed_data = check_releasedate(fixed_data)
 
         url = self._links['self']['href']
-        logger.info("patching sample %s with %s" % (self.name, sample_data))
+        logger.info("patching sample %s with %s" % (self.name, fixed_data))
 
-        Client.patch(self, url, payload=sample_data)
+        super().patch(url, payload=fixed_data)
 
         # reloading data
         self.reload()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1.dev0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/cnr-ibba/pyUSIrest',
-    version="0.3.0",
+    version="0.3.1.dev0",
     zip_safe=False,
 )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,7 +17,7 @@ from pyUSIrest.auth import Auth
 from pyUSIrest.exceptions import USIConnectionError
 
 
-def generate_token(now=None):
+def generate_token(now=None, domains=['subs.test-team-1']):
     """A function to generate a 'fake' token"""
 
     if not now:
@@ -31,7 +31,7 @@ def generate_token(now=None):
         'email': 'foo.bar@email.com',
         'nickname': 'foo',
         'name': 'Foo Bar',
-        'domains': ['subs.test-team-1']
+        'domains': domains
     }
 
     return python_jwt.generate_jwt(
@@ -122,3 +122,16 @@ class TestAuth(TestCase):
         seconds = int(duration.total_seconds())
 
         self.assertAlmostEqual(seconds, 300, delta=10)
+
+    def test_get_domains(self):
+        self.mock_get.return_value = Mock()
+        self.mock_get.return_value.text = generate_token(
+            domains=['subs.test-team-1', 'subs.test-team-2'])
+        self.mock_get.return_value.status_code = 200
+
+        auth = Auth(user='foo', password='bar')
+
+        test_domains = auth.get_domains()
+
+        self.assertEqual(
+            test_domains, ['subs.test-team-1', 'subs.test-team-2'])

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 from pyUSIrest.auth import Auth
 from pyUSIrest.usi import Root, Team, Submission
 from pyUSIrest.settings import ROOT_URL
+from pyUSIrest.exceptions import USIConnectionError, USIDataError
 
 from .common import DATA_PATH
 from .test_auth import generate_token
@@ -235,10 +236,22 @@ class RootTest(TestCase):
             self.root.get_submission_by_name,
             submission_name='c8c86558-8d3a-4ac5-8638-7aa354291d61')
 
+        # a different 40x error type
+        self.mock_get.return_value = Mock()
+        self.mock_get.return_value.text = (
+            "The request did not include an Authorization header")
+        self.mock_get.return_value.status_code = 401
+
+        self.assertRaisesRegex(
+            USIDataError,
+            "Error with request",
+            self.root.get_submission_by_name,
+            submission_name='c8c86558-8d3a-4ac5-8638-7aa354291d61')
+
         self.mock_get.return_value = Mock()
         self.mock_get.return_value.status_code = 500
 
         self.assertRaises(
-            ConnectionError,
+            USIConnectionError,
             self.root.get_submission_by_name,
             submission_name='c8c86558-8d3a-4ac5-8638-7aa354291d61')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* fix a bug when patching a sample: deal with team in relationship
* raise `USIDataError` on `40x` status code
* Change `Auth.__str__()`: now it returns `Token for Foo Bar will expire in HH:MM:SS`
* add `Auth.get_domains` which returns `self.claims['domains']`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #8 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR will solve a bug when patching a sample in a draft submission. Minor refactor of Auth class

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code has been tested using unittest and by creating/patching a BioSample submission

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
